### PR TITLE
add GHA PreviewDocumentation.yml

### DIFF
--- a/.github/workflows/PreviewDocumentation.yml
+++ b/.github/workflows/PreviewDocumentation.yml
@@ -10,7 +10,6 @@ env:
 
 jobs:
   build:
-    if:  startsWith(github.head_ref, 'documentation/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This automatically generates the docs for PRs under a separate link, that is posted in the PR conservation by a bot.